### PR TITLE
Add support for typescript.tsx filetype

### DIFF
--- a/plugin/lsp-typescript.vim
+++ b/plugin/lsp-typescript.vim
@@ -3,7 +3,7 @@ if executable('typescript-language-server')
     \ 'name': 'typescript support using typescript-language-server',
     \ 'cmd': {server_info->[&shell, &shellcmdflag, 'typescript-language-server --stdio']},
     \ 'root_uri':{server_info->lsp#utils#path_to_uri(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'tsconfig.json'))},
-    \ 'whitelist': ['typescript'],
+    \ 'whitelist': ['typescript', 'typescript.tsx'],
     \ })
 
   au User lsp_setup call lsp#register_server({


### PR DESCRIPTION
Note that `leafgarland/typescript-vim` doesn't provide that filetype. I used https://github.com/ianks/vim-tsx .